### PR TITLE
Add key exchange and UI for P2P chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build/
+CMakeFiles/
+*.o
+*.obj
+*.exe
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,22 @@
-﻿# CMakeList.txt: проект CMake для Connect; включите исходный код и определения,
-# укажите здесь логику для конкретного проекта.
-#
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
+project("Connect")
 
-# Включение горячей перезагрузки для компиляторов MSVC, если поддерживается.
-if (POLICY CMP0141)
-  cmake_policy(SET CMP0141 NEW)
-  set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<IF:$<AND:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>,$<$<CONFIG:Debug,RelWithDebInfo>:EditAndContinue>,$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>>")
-endif()
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
 
-project ("Connect")
+find_package(Qt5 REQUIRED COMPONENTS Widgets Network)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SODIUM REQUIRED libsodium)
 
-# Добавьте источник в исполняемый файл этого проекта.
-add_executable (Connect "Connect.cpp" "Connect.h")
+add_executable(Connect
+    Connect.cpp
+    Connect.h
+    Messenger.cpp
+    Messenger.h
+)
 
-if (CMAKE_VERSION VERSION_GREATER 3.12)
-  set_property(TARGET Connect PROPERTY CXX_STANDARD 20)
-endif()
+target_include_directories(Connect PRIVATE ${SODIUM_INCLUDE_DIRS})
+target_link_libraries(Connect PRIVATE Qt5::Widgets Qt5::Network ${SODIUM_LIBRARIES})
 
-# TODO: Добавьте тесты и целевые объекты, если это необходимо.
+set_target_properties(Connect PROPERTIES CXX_STANDARD 20)

--- a/Connect.cpp
+++ b/Connect.cpp
@@ -1,12 +1,80 @@
-﻿// Connect.cpp: определяет точку входа для приложения.
-//
-
 #include "Connect.h"
+#include <QApplication>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QHBoxLayout>
 
-using namespace std;
+ChatWindow::ChatWindow(QWidget* parent) : QWidget(parent) {
+    QVBoxLayout* layout = new QVBoxLayout(this);
 
-int main()
-{
-	cout << "Hello CMake." << endl;
-	return 0;
+    m_status = new QLabel("Idle", this);
+    layout->addWidget(m_status);
+
+    QHBoxLayout* configLayout = new QHBoxLayout();
+    m_listenPort = new QLineEdit(this);
+    m_listenPort->setPlaceholderText("Listen Port");
+    QPushButton* listenButton = new QPushButton("Listen", this);
+    m_peerHost = new QLineEdit(this);
+    m_peerHost->setPlaceholderText("Peer Host");
+    m_peerPort = new QLineEdit(this);
+    m_peerPort->setPlaceholderText("Peer Port");
+    QPushButton* connectButton = new QPushButton("Connect", this);
+
+    configLayout->addWidget(m_listenPort);
+    configLayout->addWidget(listenButton);
+    configLayout->addWidget(m_peerHost);
+    configLayout->addWidget(m_peerPort);
+    configLayout->addWidget(connectButton);
+    layout->addLayout(configLayout);
+
+    m_chat = new QTextEdit(this);
+    m_chat->setReadOnly(true);
+    m_input = new QLineEdit(this);
+    QPushButton* sendButton = new QPushButton("Send", this);
+
+    layout->addWidget(m_chat);
+    layout->addWidget(m_input);
+    layout->addWidget(sendButton);
+
+    connect(sendButton, &QPushButton::clicked, this, &ChatWindow::onSend);
+    connect(listenButton, &QPushButton::clicked, this, &ChatWindow::onStartServer);
+    connect(connectButton, &QPushButton::clicked, this, &ChatWindow::onConnectClicked);
+    connect(&m_messenger, &Messenger::messageReceived, this, &ChatWindow::onMessageReceived);
+    connect(&m_messenger, &Messenger::connectionStatusChanged, this, &ChatWindow::onStatusChanged);
+    connect(&m_messenger, &Messenger::errorOccurred, this, &ChatWindow::onStatusChanged);
+}
+
+void ChatWindow::connectToPeer(const QString& host, quint16 port) {
+    m_messenger.connectToHost(host, port);
+}
+
+void ChatWindow::onSend() {
+    QByteArray msg = m_input->text().toUtf8();
+    m_messenger.sendMessage(msg);
+    m_chat->append("Me: " + m_input->text());
+    m_input->clear();
+}
+
+void ChatWindow::onMessageReceived(const QByteArray& msg) {
+    m_chat->append("Peer: " + QString::fromUtf8(msg));
+}
+
+void ChatWindow::onStartServer() {
+    quint16 port = m_listenPort->text().toUShort();
+    m_messenger.startServer(port);
+}
+
+void ChatWindow::onConnectClicked() {
+    connectToPeer(m_peerHost->text(), m_peerPort->text().toUShort());
+}
+
+void ChatWindow::onStatusChanged(const QString& status) {
+    m_status->setText(status);
+}
+
+int main(int argc, char* argv[]) {
+    QApplication app(argc, argv);
+    ChatWindow window;
+    window.show();
+    return app.exec();
 }

--- a/Connect.h
+++ b/Connect.h
@@ -1,8 +1,32 @@
-﻿// Connect.h : включаемый файл для стандартных системных включаемых файлов
-// или включаемые файлы для конкретного проекта.
-
 #pragma once
 
-#include <iostream>
+#include <QWidget>
+#include <QTextEdit>
+#include <QLineEdit>
+#include <QLabel>
+#include <QPushButton>
+#include "Messenger.h"
 
-// TODO: установите здесь ссылки на дополнительные заголовки, требующиеся для программы.
+class ChatWindow : public QWidget {
+    Q_OBJECT
+public:
+    ChatWindow(QWidget* parent = nullptr);
+
+    void connectToPeer(const QString& host, quint16 port);
+private slots:
+    void onSend();
+    void onMessageReceived(const QByteArray& msg);
+    void onStartServer();
+    void onConnectClicked();
+    void onStatusChanged(const QString& status);
+
+private:
+    Messenger m_messenger;
+    QTextEdit* m_chat;
+    QLineEdit* m_input;
+    QLineEdit* m_listenPort;
+    QLineEdit* m_peerHost;
+    QLineEdit* m_peerPort;
+    QLabel* m_status;
+}; 
+

--- a/Messenger.cpp
+++ b/Messenger.cpp
@@ -1,0 +1,164 @@
+#include "Messenger.h"
+#include <QDataStream>
+#include <QDebug>
+
+Messenger::Messenger(QObject* parent)
+    : QObject(parent), m_socket(new QTcpSocket(this)), m_server(new QTcpServer(this)) {
+    if (sodium_init() < 0) {
+        qFatal("Failed to initialize libsodium");
+    }
+    loadIdentity();
+    connect(m_socket, &QTcpSocket::readyRead, this, &Messenger::onReadyRead);
+    connect(m_socket, &QTcpSocket::connected, this, [this]() {
+        m_isServer = false;
+        sendPublicKey();
+        emit connectionStatusChanged("Connected");
+    });
+    connect(m_socket, &QTcpSocket::disconnected, this, [this]() {
+        m_handshakeDone = false;
+        emit connectionStatusChanged("Disconnected");
+    });
+    connect(m_socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError){
+        emit errorOccurred(m_socket->errorString());
+    });
+    connect(m_server, &QTcpServer::newConnection, this, &Messenger::onNewConnection);
+}
+
+Messenger::~Messenger() {}
+
+bool Messenger::startServer(quint16 port) {
+    bool ok = m_server->listen(QHostAddress::Any, port);
+    if (!ok)
+        emit errorOccurred(m_server->errorString());
+    else
+        emit connectionStatusChanged(QString("Listening on %1").arg(port));
+    return ok;
+}
+
+void Messenger::connectToHost(const QString& host, quint16 port) {
+    if (m_socket->isOpen())
+        m_socket->disconnectFromHost();
+    m_socket->connectToHost(host, port);
+}
+
+void Messenger::sendMessage(const QByteArray& message) {
+    if (!m_handshakeDone || m_socket->state() != QAbstractSocket::ConnectedState) {
+        emit errorOccurred("Not connected");
+        return;
+    }
+
+    QByteArray cipher(message.size() + crypto_secretbox_MACBYTES, 0);
+    unsigned char nonce[crypto_secretbox_NONCEBYTES];
+    randombytes_buf(nonce, sizeof nonce);
+
+    crypto_secretbox_easy((unsigned char*)cipher.data(),
+                    (const unsigned char*)message.data(), message.size(),
+                    nonce, m_tx);
+
+    QByteArray packet;
+    QDataStream out(&packet, QIODevice::WriteOnly);
+    out.setByteOrder(QDataStream::LittleEndian);
+    quint32 len = sizeof nonce + cipher.size();
+    out << len;
+    out.writeRawData((char*)nonce, sizeof nonce);
+    out.writeRawData(cipher.data(), cipher.size());
+
+    qint64 written = m_socket->write(packet);
+    if (written != packet.size())
+        emit errorOccurred("Failed to send packet");
+}
+
+void Messenger::onReadyRead() {
+    m_buffer.append(m_socket->readAll());
+
+    while (true) {
+        if (!m_handshakeDone) {
+            if (m_buffer.size() < crypto_kx_PUBLICKEYBYTES)
+                return;
+            memcpy(m_peerPk, m_buffer.constData(), crypto_kx_PUBLICKEYBYTES);
+            m_buffer.remove(0, crypto_kx_PUBLICKEYBYTES);
+            int ret;
+            if (m_isServer)
+                ret = crypto_kx_server_session_keys(m_rx, m_tx, m_pk, m_sk, m_peerPk);
+            else
+                ret = crypto_kx_client_session_keys(m_rx, m_tx, m_pk, m_sk, m_peerPk);
+            if (ret != 0) {
+                emit errorOccurred("Handshake failed");
+                m_socket->disconnectFromHost();
+                return;
+            }
+            m_handshakeDone = true;
+            emit connectionStatusChanged("Secure channel established");
+            continue;
+        }
+
+        if (m_buffer.size() < 4)
+            return;
+        QDataStream in(m_buffer);
+        in.setByteOrder(QDataStream::LittleEndian);
+        quint32 len;
+        in >> len;
+        if (m_buffer.size() < 4 + len)
+            return;
+        m_buffer.remove(0, 4);
+        QByteArray payload = m_buffer.left(len);
+        m_buffer.remove(0, len);
+
+        const unsigned char* nonce = (const unsigned char*)payload.constData();
+        QByteArray cipher = payload.mid(crypto_secretbox_NONCEBYTES);
+        QByteArray message(cipher.size() - crypto_secretbox_MACBYTES, 0);
+        if (crypto_secretbox_open_easy((unsigned char*)message.data(),
+                                 (const unsigned char*)cipher.data(), cipher.size(),
+                                 nonce, m_rx) == 0) {
+            emit messageReceived(message);
+        } else {
+            emit errorOccurred("Decryption failed");
+        }
+    }
+}
+
+void Messenger::onNewConnection() {
+    QTcpSocket* client = m_server->nextPendingConnection();
+    if (!client) return;
+
+    if (m_socket->state() == QAbstractSocket::ConnectedState) {
+        client->close();
+        client->deleteLater();
+        return;
+    }
+
+    m_socket->deleteLater();
+    m_socket = client;
+    m_isServer = true;
+    m_handshakeDone = false;
+    connect(m_socket, &QTcpSocket::readyRead, this, &Messenger::onReadyRead);
+    connect(m_socket, &QTcpSocket::disconnected, this, [this]() {
+        m_handshakeDone = false;
+        emit connectionStatusChanged("Disconnected");
+    });
+    connect(m_socket, &QTcpSocket::errorOccurred, this, [this](QAbstractSocket::SocketError){
+        emit errorOccurred(m_socket->errorString());
+    });
+    sendPublicKey();
+    emit connectionStatusChanged("Client connected");
+}
+
+void Messenger::sendPublicKey() {
+    m_socket->write(QByteArray((char*)m_pk, crypto_kx_PUBLICKEYBYTES));
+}
+
+void Messenger::loadIdentity() {
+    QFile f("identity.key");
+    if (f.open(QIODevice::ReadOnly)) {
+        f.read((char*)m_pk, crypto_kx_PUBLICKEYBYTES);
+        f.read((char*)m_sk, crypto_kx_SECRETKEYBYTES);
+        f.close();
+    } else {
+        crypto_kx_keypair(m_pk, m_sk);
+        if (f.open(QIODevice::WriteOnly)) {
+            f.write((char*)m_pk, crypto_kx_PUBLICKEYBYTES);
+            f.write((char*)m_sk, crypto_kx_SECRETKEYBYTES);
+            f.close();
+        }
+    }
+}

--- a/Messenger.h
+++ b/Messenger.h
@@ -1,0 +1,50 @@
+#ifndef MESSENGER_H
+#define MESSENGER_H
+
+#include <QTcpSocket>
+#include <QTcpServer>
+#include <QByteArray>
+#include <QObject>
+#include <QFile>
+#include <sodium.h>
+
+class Messenger : public QObject {
+    Q_OBJECT
+public:
+    explicit Messenger(QObject* parent = nullptr);
+    ~Messenger();
+
+    bool startServer(quint16 port);
+    void connectToHost(const QString& host, quint16 port);
+
+    void sendMessage(const QByteArray& message);
+
+signals:
+    void messageReceived(const QByteArray& message);
+    void connectionStatusChanged(const QString& status);
+    void errorOccurred(const QString& error);
+
+private slots:
+    void onReadyRead();
+    void onNewConnection();
+
+private:
+    void sendPublicKey();
+    void loadIdentity();
+
+    unsigned char m_pk[crypto_kx_PUBLICKEYBYTES];
+    unsigned char m_sk[crypto_kx_SECRETKEYBYTES];
+    unsigned char m_peerPk[crypto_kx_PUBLICKEYBYTES];
+    unsigned char m_rx[crypto_kx_SESSIONKEYBYTES];
+    unsigned char m_tx[crypto_kx_SESSIONKEYBYTES];
+
+    QByteArray m_buffer;
+    bool m_isServer = false;
+    bool m_handshakeDone = false;
+
+    QTcpSocket* m_socket;
+    QTcpServer* m_server;
+
+};
+
+#endif // MESSENGER_H


### PR DESCRIPTION
## Summary
- implement libsodium key exchange using `crypto_kx`
- persist identity key pair locally
- add message framing with length prefixes
- update Qt UI with connection controls and status display

## Testing
- `cmake -B build -S .`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685be1b734cc832187c72587a11c28df